### PR TITLE
fix: update PHP version to 8.4 to match Symfony 8.0 dependencies

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, xml, ctype, json, dom
           coverage: xdebug
 


### PR DESCRIPTION
## Summary

Fixes the CI failure on the main branch by updating the PHP version in the gate workflow from 8.3 to 8.4.

## Problem

The gate repo's CI is failing on the main branch with:
```
your php version (8.3.28) does not satisfy that requirement
```

This is because `composer.lock` contains Symfony 8.0.x packages that require PHP >=8.4:
- `symfony/clock` v8.0.0 requires PHP >=8.4
- `symfony/string` v8.0.1 requires PHP >=8.4
- `symfony/translation` v8.0.1 requires PHP >=8.4

The `action.yml` already correctly defaults to PHP 8.4, but the self-test workflow (`.github/workflows/gate.yml`) was still using PHP 8.3.

## Changes

- Updated `.github/workflows/gate.yml` to use `php-version: '8.4'` instead of `'8.3'`

## Test Plan

- [ ] Verify the PR passes CI (composer install should succeed)
- [ ] Verify all gate checks pass
- [ ] Confirm this matches the PHP version used in action.yml (8.4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP version in continuous integration workflow from 8.3 to 8.4.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->