### PR TITLE
feat: preserve issue-closing keywords in squash merge commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,23 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        gh pr merge ${{ github.event.pull_request.number }} \
-          --${{ inputs.merge-method }} \
-          --delete-branch
+        # Extract issue-closing keywords (Closes #X, Fixes #X, Resolves #X)
+        ISSUE_REFS=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | sort -u || true)
+
+        # Merge with issue references in commit body if found
+        if [ -n "$ISSUE_REFS" ]; then
+          COMMIT_BODY=$(printf '%s\n' $ISSUE_REFS)
+          gh pr merge "$PR_NUMBER" \
+            --${{ inputs.merge-method }} \
+            --subject "$PR_TITLE (#$PR_NUMBER)" \
+            --body "$COMMIT_BODY" \
+            --delete-branch
+        else
+          gh pr merge "$PR_NUMBER" \
+            --${{ inputs.merge-method }} \
+            --delete-branch
+        fi


### PR DESCRIPTION
## Summary

When PRs contain issue-closing keywords (Closes #X, Fixes #X, Resolves #X), extract them from the PR body and include in the squash merge commit message. This allows GitHub to auto-close linked issues when the PR is merged.

## Changes

- Modified `action.yml` auto-merge step to:
  1. Extract issue-closing keywords from PR body using grep
  2. Include keywords in the squash merge commit body via `--body` flag
  3. Only add custom commit message when keywords are present

## Test Plan

- [ ] Create test PR with `Closes #X` in body
- [ ] Verify squash merge commit message contains the keyword
- [ ] Verify linked issue is auto-closed

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced automated merge process to intelligently preserve issue references. When merging pull requests, the system now automatically detects and includes issue references from PR descriptions in merge commits, improving issue tracking and project visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->