### PR TITLE
fix: match actual Pest coverage failure format

### DIFF
--- a/app/Services/PestOutputParser.php
+++ b/app/Services/PestOutputParser.php
@@ -26,7 +26,8 @@ final class PestOutputParser
 
     public function isCoverageBelowThreshold(string $output): ?float
     {
-        return preg_match('/Code coverage below expected:\s*([\d.]+)%/', $output, $m) ? (float) $m[1] : null;
+        // Pest format: "FAIL  Code coverage below expected  X %, currently  Y %."
+        return preg_match('/Code coverage below expected.*?currently\s+([\d.]+)\s*%/i', $output, $m) ? (float) $m[1] : null;
     }
 
     private function formatFailure(string $name, string $body): string

--- a/tests/Unit/Checks/TestRunnerTest.php
+++ b/tests/Unit/Checks/TestRunnerTest.php
@@ -74,7 +74,7 @@ OUTPUT,
             ->once()
             ->andReturn(new ProcessResult(
                 successful: false,
-                output: "Tests:  5 passed\nCode coverage below expected: 89.50%",
+                output: "Tests:  5 passed\nFAIL  Code coverage below expected  100.0 %, currently  89.50 %.",
             ));
 
         $runner = new TestRunner(

--- a/tests/Unit/Services/PestOutputParserTest.php
+++ b/tests/Unit/Services/PestOutputParserTest.php
@@ -143,7 +143,7 @@ OUTPUT;
     describe('isCoverageBelowThreshold', function () {
         it('detects coverage below threshold', function () {
             $parser = new PestOutputParser();
-            $output = 'Code coverage below expected: 89.50%';
+            $output = 'FAIL  Code coverage below expected  100.0 %, currently  89.50 %.';
             expect($parser->isCoverageBelowThreshold($output))->toBe(89.5);
         });
 


### PR DESCRIPTION
Regex wasn't matching actual Pest output format for coverage failures.