### PR TITLE
feat: show file-level coverage details in failure output

### DIFF
--- a/app/Checks/TestRunner.php
+++ b/app/Checks/TestRunner.php
@@ -66,6 +66,16 @@ final class TestRunner implements CheckInterface
 
         if ($actual = $this->parser->isCoverageBelowThreshold($output)) {
             $details[] = "Coverage: {$actual}% (threshold: {$this->coverageThreshold}%)";
+
+            // Add files missing coverage (limit to 5)
+            $uncovered = $this->parser->parseFileCoverage($output, (float) $this->coverageThreshold);
+            foreach (array_slice($uncovered, 0, 5, true) as $file => $coverage) {
+                $details[] = "  {$file}: {$coverage}%";
+            }
+
+            if (count($uncovered) > 5) {
+                $details[] = '  ...and '.(count($uncovered) - 5).' more files';
+            }
         }
 
         return $details;

--- a/app/Services/PestOutputParser.php
+++ b/app/Services/PestOutputParser.php
@@ -30,6 +30,31 @@ final class PestOutputParser
         return preg_match('/Code coverage below expected.*?currently\s+([\d.]+)\s*%/i', $output, $m) ? (float) $m[1] : null;
     }
 
+    /**
+     * Parse file coverage and return files below threshold.
+     *
+     * @return array<string, float> File path => coverage percentage
+     */
+    public function parseFileCoverage(string $output, float $threshold = 100.0): array
+    {
+        $uncovered = [];
+
+        // Pest format: "  FileName/Path ............ XX.X%"
+        preg_match_all('/^\s{2}(\S+)\s+\.+\s+([\d.]+)%/m', $output, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $file = $match[1];
+            $coverage = (float) $match[2];
+
+            // Skip "Total" line and files meeting threshold
+            if ($file !== 'Total' && $coverage < $threshold) {
+                $uncovered[$file] = $coverage;
+            }
+        }
+
+        return $uncovered;
+    }
+
     private function formatFailure(string $name, string $body): string
     {
         $name = preg_replace('/\s+[\d.]+s$/', '', trim($name));

--- a/tests/Unit/Checks/TestRunnerTest.php
+++ b/tests/Unit/Checks/TestRunnerTest.php
@@ -163,4 +163,69 @@ OUTPUT,
         expect($result->passed)->toBeTrue();
         expect($result->message)->toBe('5 tests passed');
     });
+
+    it('includes file coverage details when below threshold', function () {
+        $mockRunner = mock(ProcessRunner::class);
+        $mockRunner->shouldReceive('run')
+            ->once()
+            ->andReturn(new ProcessResult(
+                successful: false,
+                output: <<<'OUTPUT'
+Tests:  5 passed
+  App/Services/FooService .............. 85.0%
+  App/Services/BarService .............. 92.5%
+  App/Services/BazService .............. 100.0%
+  Total ................................ 95.0%
+FAIL  Code coverage below expected  100.0 %, currently  95.0 %.
+OUTPUT,
+            ));
+
+        $runner = new TestRunner(
+            coverageThreshold: 100,
+            parser: new PestOutputParser(),
+            processRunner: $mockRunner,
+        );
+
+        $result = $runner->run('/tmp');
+
+        expect($result->passed)->toBeFalse();
+        expect($result->details)->toContain('Coverage: 95% (threshold: 100%)');
+        expect($result->details)->toContain('  App/Services/FooService: 85%');
+        expect($result->details)->toContain('  App/Services/BarService: 92.5%');
+    });
+
+    it('limits file coverage details to 5 files', function () {
+        $mockRunner = mock(ProcessRunner::class);
+        $mockRunner->shouldReceive('run')
+            ->once()
+            ->andReturn(new ProcessResult(
+                successful: false,
+                output: <<<'OUTPUT'
+Tests:  5 passed
+  App/Services/Service1 .............. 80.0%
+  App/Services/Service2 .............. 81.0%
+  App/Services/Service3 .............. 82.0%
+  App/Services/Service4 .............. 83.0%
+  App/Services/Service5 .............. 84.0%
+  App/Services/Service6 .............. 85.0%
+  App/Services/Service7 .............. 86.0%
+  Total ............................... 83.0%
+FAIL  Code coverage below expected  100.0 %, currently  83.0 %.
+OUTPUT,
+            ));
+
+        $runner = new TestRunner(
+            coverageThreshold: 100,
+            parser: new PestOutputParser(),
+            processRunner: $mockRunner,
+        );
+
+        $result = $runner->run('/tmp');
+
+        expect($result->passed)->toBeFalse();
+        // Should have: coverage summary + 5 files + "...and X more files"
+        $fileDetails = array_filter($result->details, fn ($d) => str_starts_with($d, '  App/'));
+        expect($fileDetails)->toHaveCount(5);
+        expect($result->details)->toContain('  ...and 2 more files');
+    });
 });

--- a/tests/Unit/Services/PestOutputParserTest.php
+++ b/tests/Unit/Services/PestOutputParserTest.php
@@ -159,4 +159,65 @@ OUTPUT;
             expect($parser->isCoverageBelowThreshold($output))->toBeNull();
         });
     });
+
+    describe('parseFileCoverage', function () {
+        it('extracts files below threshold', function () {
+            $parser = new PestOutputParser();
+            $output = <<<'OUTPUT'
+  App/Services/FooService .............. 85.0%
+  App/Services/BarService .............. 92.5%
+  App/Services/BazService .............. 100.0%
+  Total ................................ 95.0%
+OUTPUT;
+            $uncovered = $parser->parseFileCoverage($output, 100.0);
+
+            expect($uncovered)->toHaveCount(2);
+            expect($uncovered['App/Services/FooService'])->toBe(85.0);
+            expect($uncovered['App/Services/BarService'])->toBe(92.5);
+        });
+
+        it('excludes Total line', function () {
+            $parser = new PestOutputParser();
+            $output = <<<'OUTPUT'
+  App/Services/FooService .............. 85.0%
+  Total ................................ 85.0%
+OUTPUT;
+            $uncovered = $parser->parseFileCoverage($output, 100.0);
+
+            expect($uncovered)->toHaveCount(1);
+            expect($uncovered)->not->toHaveKey('Total');
+        });
+
+        it('returns empty array when all files meet threshold', function () {
+            $parser = new PestOutputParser();
+            $output = <<<'OUTPUT'
+  App/Services/FooService .............. 100.0%
+  App/Services/BarService .............. 100.0%
+  Total ................................ 100.0%
+OUTPUT;
+            $uncovered = $parser->parseFileCoverage($output, 100.0);
+
+            expect($uncovered)->toBeEmpty();
+        });
+
+        it('respects custom threshold', function () {
+            $parser = new PestOutputParser();
+            $output = <<<'OUTPUT'
+  App/Services/FooService .............. 75.0%
+  App/Services/BarService .............. 85.0%
+  Total ................................ 80.0%
+OUTPUT;
+            $uncovered = $parser->parseFileCoverage($output, 80.0);
+
+            expect($uncovered)->toHaveCount(1);
+            expect($uncovered['App/Services/FooService'])->toBe(75.0);
+        });
+
+        it('returns empty array when no coverage output', function () {
+            $parser = new PestOutputParser();
+            $output = 'Tests:  5 passed';
+
+            expect($parser->parseFileCoverage($output))->toBeEmpty();
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Adds `parseFileCoverage()` method to PestOutputParser
- Extracts files below threshold from Pest coverage output
- Shows up to 5 files with their coverage percentages in failure details
- Includes "...and X more files" message when more than 5 files are below threshold

## Example Output
When coverage fails, details now show:
```
Coverage: 95% (threshold: 100%)
  App/Services/FooService: 85%
  App/Services/BarService: 92.5%
```

## Test plan
- [x] Added tests for parseFileCoverage() in PestOutputParserTest
- [x] Added tests for file details in TestRunnerTest
- [x] 100% coverage maintained (120 tests)