### PR TITLE
Add compact output mode for cleaner CI logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,16 @@ Built with Laravel Zero for clean CLI architecture.
 ## Development Commands
 
 ```bash
-# Run the gate locally
-php gate run --coverage=100
+# Run full certification (all checks)
+php gate certify --coverage=80
+
+# Run full certification with compact output
+php gate certify --coverage=80 --compact
+
+# Run individual checks
+php gate tests --coverage=80
+php gate security
+php gate syntax
 
 # Run tests
 vendor/bin/pest
@@ -29,7 +37,7 @@ composer audit
 ### GitHub Action Flow
 Consumer repos use: `uses: synapse-sentinel/gate@v1`
 → Composite action sets up PHP
-→ Runs `php gate run`
+→ Runs `php gate certify`
 → Outputs verdict + annotations
 → Exit 0 (green) or 1 (red)
 
@@ -37,13 +45,19 @@ Consumer repos use: `uses: synapse-sentinel/gate@v1`
 
 ```
 app/
-├── Commands/RunCommand.php    # CLI entry point
+├── Commands/
+│   ├── CertifyCommand.php     # Full certification (all checks)
+│   ├── TestsCommand.php       # Tests + coverage check
+│   ├── SecurityCommand.php    # Security audit
+│   └── SyntaxCommand.php      # Pest syntax validation
 ├── Verdict.php                # Value object (approved/rejected/escalate)
 ├── Checks/                    # Individual quality checks
 │   ├── CheckInterface.php
-│   ├── TestRunner.php         # pest --coverage --min=X (tests + coverage in one run)
+│   ├── TestRunner.php         # pest --coverage --min=X
 │   ├── SecurityScanner.php    # composer audit
 │   └── PestSyntaxValidator.php # Validates describe/it blocks
+├── GitHub/
+│   └── ChecksClient.php       # GitHub Checks API integration
 └── Stages/
     └── TechnicalGate.php      # Orchestrates all checks
 ```

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Merge method: squash, merge, or rebase'
     required: false
     default: 'squash'
+  compact:
+    description: 'Use compact single-line output instead of verbose'
+    required: false
+    default: 'false'
 
 outputs:
   verdict:
@@ -88,7 +92,8 @@ runs:
           certify|*)
             php ${{ github.action_path }}/gate certify \
               --coverage=${{ inputs.coverage-threshold }} \
-              --token=${{ inputs.github-token }}
+              --token=${{ inputs.github-token }} \
+              ${{ inputs.compact == 'true' && '--compact' || '' }}
             ;;
         esac
 

--- a/app/Commands/CertifyCommand.php
+++ b/app/Commands/CertifyCommand.php
@@ -22,7 +22,8 @@ final class CertifyCommand extends Command
 {
     protected $signature = 'certify
         {--coverage=80 : Minimum coverage threshold percentage}
-        {--token= : GitHub token for Checks API}';
+        {--token= : GitHub token for Checks API}
+        {--compact : Show single-line output instead of verbose}';
 
     protected $description = 'Run all checks and issue Sentinel Certification';
 
@@ -30,6 +31,7 @@ final class CertifyCommand extends Command
     {
         $coverageThreshold = (int) $this->option('coverage');
         $token = $this->option('token') ?: getenv('GITHUB_TOKEN') ?: null;
+        $compact = (bool) $this->option('compact');
         $checksClient = new ChecksClient($token);
         $workingDirectory = getcwd();
 
@@ -41,9 +43,15 @@ final class CertifyCommand extends Command
 
         $failures = [];
         $failureRows = [];
+        $compactResults = [];
 
         foreach ($checks as $check) {
-            $result = $this->runCheck($check, $workingDirectory, $checksClient);
+            $result = $this->runCheck($check, $workingDirectory, $checksClient, $compact);
+            $compactResults[] = [
+                'name' => $this->shortName($check->name()),
+                'passed' => $result->passed,
+                'message' => $result->message,
+            ];
             if (! $result->passed) {
                 $failures[] = "[{$check->name()}] {$result->message}";
                 foreach ($result->details as $detail) {
@@ -70,7 +78,9 @@ final class CertifyCommand extends Command
         );
 
         // Output verdict
-        if ($verdict->isApproved()) {
+        if ($compact) {
+            $this->renderCompactOutput($compactResults, $verdict);
+        } elseif ($verdict->isApproved()) {
             info('');
             info('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
             info('  ✓ SENTINEL CERTIFICATION: APPROVED');
@@ -109,11 +119,16 @@ final class CertifyCommand extends Command
         CheckInterface $check,
         string $workingDirectory,
         ChecksClient $checksClient,
+        bool $compact = false,
     ): \App\Checks\CheckResult {
-        $result = spin(
-            fn () => $check->run($workingDirectory),
-            "Running {$check->name()}..."
-        );
+        if ($compact) {
+            $result = $check->run($workingDirectory);
+        } else {
+            $result = spin(
+                fn () => $check->run($workingDirectory),
+                "Running {$check->name()}..."
+            );
+        }
 
         // Report to GitHub Checks API
         $checksClient->reportCheck(
@@ -123,13 +138,43 @@ final class CertifyCommand extends Command
             summary: $result->message,
         );
 
-        // Console output
-        if ($result->passed) {
-            info("{$check->name()} ✓");
-        } else {
-            error("{$check->name()} ✗");
+        // Console output (skip in compact mode - we'll show summary at end)
+        if (! $compact) {
+            if ($result->passed) {
+                info("{$check->name()} ✓");
+            } else {
+                error("{$check->name()} ✗");
+            }
         }
 
         return $result;
+    }
+
+    private function shortName(string $name): string
+    {
+        return match ($name) {
+            'Tests & Coverage' => 'Tests',
+            'Security Audit' => 'Security',
+            'Pest Syntax' => 'Syntax',
+            default => $name,
+        };
+    }
+
+    private function renderCompactOutput(array $results, Verdict $verdict): void
+    {
+        $parts = [];
+        foreach ($results as $r) {
+            $icon = $r['passed'] ? '✓' : '✗';
+            $parts[] = "{$r['name']} {$icon}";
+        }
+
+        $status = $verdict->isApproved() ? '✓ APPROVED' : '✗ REJECTED';
+        $line = implode('  ', $parts) . "  │  {$status}";
+
+        if ($verdict->isApproved()) {
+            info($line);
+        } else {
+            error($line);
+        }
     }
 }

--- a/tests/Feature/RunCommandTest.php
+++ b/tests/Feature/RunCommandTest.php
@@ -70,5 +70,13 @@ describe('Gate Commands', function () {
             $command = new CertifyCommand();
             expect($command->getDefinition()->hasOption('token'))->toBeTrue();
         });
+
+        it('has compact option', function () {
+            $command = new CertifyCommand();
+            $definition = $command->getDefinition();
+
+            expect($definition->hasOption('compact'))->toBeTrue();
+            expect($definition->getOption('compact')->getDefault())->toBeFalse();
+        });
     });
 });


### PR DESCRIPTION
- Add --compact flag to CertifyCommand for single-line output
- Update action.yml to expose compact input option
- Fix CLAUDE.md to reflect actual command names (certify, not run)
- Add test for compact option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Certification workflow replaces gate run as the primary command.
  * Added --compact flag for condensed certification output.
  * New specialized commands for tests, security, and syntax checks.

* **Documentation**
  * Updated documentation to reflect new certification command structure and options.

* **Tests**
  * Added verification for compact option availability and defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->