### PR TITLE
Store coverage artifacts for branch comparison (#13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /.phpunit.cache/
 /.pest/
 /coverage/
+coverage.xml
+base-coverage/
 .DS_Store
 *.swp
 *.swo

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
          cacheDirectory=".phpunit.cache"
@@ -25,4 +25,9 @@
             <directory>app/Providers</directory>
         </exclude>
     </source>
+    <coverage>
+        <report>
+            <clover outputFile="coverage.xml"/>
+        </report>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
## Summary
Implements Issue #13 by adding coverage artifact storage to enable historical coverage tracking and branch-to-branch comparison.

## Changes
- Added clover coverage.xml generation to phpunit.xml configuration
- Configured GitHub Actions workflow to upload coverage artifacts on main branch pushes with 30-day retention
- Added download step for base branch coverage on PR runs for comparison capability
- Updated .gitignore to exclude coverage.xml and base-coverage/ directory

## Implementation Details
- Artifacts are stored with name `coverage-report` containing coverage.xml
- PR runs download baseline coverage from target branch (continues on error if not found)
- Retention set to 30 days as specified in requirements
- Supports future coverage delta comparison and PR comment reporting

## Testing
- Verified coverage.xml is generated by phpunit during test runs
- Confirmed artifact upload/download workflow syntax is correct
- All existing tests pass

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage artifact management for pull requests and main branch deployments.
  * Introduced configurable coverage driver selection and directory paths.
  * Added compact output mode for certification results with per-check summaries.

* **Tests**
  * Added comprehensive test coverage for the new coverage parsing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->