### PR TITLE
fix: Skip files without metrics instead of adding empty arrays

### DIFF
--- a/app/Branding.php
+++ b/app/Branding.php
@@ -8,8 +8,11 @@ final class Branding
 {
     // Check names (sorted by display order)
     public const TESTS = '① Tests & Coverage';
+
     public const SECURITY = '② Security Audit';
+
     public const SYNTAX = '③ Pest Syntax';
+
     public const CERTIFICATION = '🏆 Sentinel Certified';
 
     // Map internal names to branded names

--- a/app/Checks/CheckInterface.php
+++ b/app/Checks/CheckInterface.php
@@ -7,5 +7,6 @@ namespace App\Checks;
 interface CheckInterface
 {
     public function name(): string;
+
     public function run(string $workingDirectory): CheckResult;
 }

--- a/app/Checks/PestSyntaxValidator.php
+++ b/app/Checks/PestSyntaxValidator.php
@@ -15,13 +15,13 @@ final class PestSyntaxValidator implements CheckInterface
 
     public function run(string $workingDirectory): CheckResult
     {
-        $testsPath = $workingDirectory . '/tests';
+        $testsPath = $workingDirectory.'/tests';
 
-        if (!is_dir($testsPath)) {
+        if (! is_dir($testsPath)) {
             return CheckResult::pass('No tests directory found');
         }
 
-        $finder = new Finder();
+        $finder = new Finder;
         $finder->files()->in($testsPath)->name('*Test.php');
 
         $violations = [];
@@ -31,7 +31,7 @@ final class PestSyntaxValidator implements CheckInterface
 
             // Check for test() function usage (but not in comments)
             if (preg_match('/^\s*test\s*\(/m', $contents)) {
-                $violations[] = $file->getRelativePathname() . ': Uses test() instead of describe/it blocks';
+                $violations[] = $file->getRelativePathname().': Uses test() instead of describe/it blocks';
             }
         }
 

--- a/app/Checks/SecurityScanner.php
+++ b/app/Checks/SecurityScanner.php
@@ -10,7 +10,7 @@ use App\Services\SymfonyProcessRunner;
 final class SecurityScanner implements CheckInterface
 {
     public function __construct(
-        private readonly ProcessRunner $processRunner = new SymfonyProcessRunner(),
+        private readonly ProcessRunner $processRunner = new SymfonyProcessRunner,
     ) {}
 
     public function name(): string

--- a/app/Checks/TestRunner.php
+++ b/app/Checks/TestRunner.php
@@ -18,8 +18,8 @@ final class TestRunner implements CheckInterface
 
     public function __construct(
         private readonly int $coverageThreshold = 100,
-        private readonly PestOutputParser $parser = new PestOutputParser(),
-        private readonly ProcessRunner $processRunner = new SymfonyProcessRunner(),
+        private readonly PestOutputParser $parser = new PestOutputParser,
+        private readonly ProcessRunner $processRunner = new SymfonyProcessRunner,
     ) {}
 
     /** @internal For testing only */
@@ -40,7 +40,7 @@ final class TestRunner implements CheckInterface
 
     public function run(string $workingDirectory): CheckResult
     {
-        $cloverPath = $workingDirectory . '/coverage.xml';
+        $cloverPath = $workingDirectory.'/coverage.xml';
 
         $result = $this->processRunner->run(
             ['vendor/bin/pest', '--coverage', "--min={$this->coverageThreshold}", "--coverage-clover={$cloverPath}", '--colors=never'],

--- a/app/Commands/CertifyCommand.php
+++ b/app/Commands/CertifyCommand.php
@@ -61,8 +61,8 @@ final class CertifyCommand extends Command
 
         $checks = $this->checks ?? [
             new TestRunner($coverageThreshold),
-            new SecurityScanner(),
-            new PestSyntaxValidator(),
+            new SecurityScanner,
+            new PestSyntaxValidator,
         ];
 
         $stopOnFailure = $this->option('stop-on-failure');
@@ -100,7 +100,7 @@ final class CertifyCommand extends Command
         // Report Sentinel Certification (last, after all checks)
         $title = $verdict->isApproved()
             ? 'All checks passed'
-            : count($failures) . ' check(s) failed';
+            : count($failures).' check(s) failed';
 
         $checksClient->reportCheck(
             name: Branding::CERTIFICATION,
@@ -206,7 +206,7 @@ final class CertifyCommand extends Command
         }
 
         $status = $verdict->isApproved() ? '✓ APPROVED' : '✗ REJECTED';
-        $line = implode('  ', $parts) . "  │  {$status}";
+        $line = implode('  ', $parts)."  │  {$status}";
 
         if ($verdict->isApproved()) {
             info($line);

--- a/app/Commands/SecurityCommand.php
+++ b/app/Commands/SecurityCommand.php
@@ -43,7 +43,7 @@ final class SecurityCommand extends Command
     {
         $token = $this->option('token') ?: getenv('GITHUB_TOKEN') ?: null;
         $checksClient = $this->checksClient ?? new ChecksClient($token);
-        $check = $this->check ?? new SecurityScanner();
+        $check = $this->check ?? new SecurityScanner;
 
         $result = $check->run(getcwd());
 

--- a/app/Commands/SyntaxCommand.php
+++ b/app/Commands/SyntaxCommand.php
@@ -43,7 +43,7 @@ final class SyntaxCommand extends Command
     {
         $token = $this->option('token') ?: getenv('GITHUB_TOKEN') ?: null;
         $checksClient = $this->checksClient ?? new ChecksClient($token);
-        $check = $this->check ?? new PestSyntaxValidator();
+        $check = $this->check ?? new PestSyntaxValidator;
 
         $result = $check->run(getcwd());
 

--- a/app/GitHub/ChecksClient.php
+++ b/app/GitHub/ChecksClient.php
@@ -130,6 +130,7 @@ final class ChecksClient
         if (! $this->isAvailable()) {
             $hasToken = $this->token ? 'yes' : 'no';
             echo "::warning::ChecksClient not available (token={$hasToken}, repo={$this->repo}, sha={$this->sha})\n";
+
             return false;
         }
 
@@ -152,6 +153,7 @@ final class ChecksClient
             return true;
         } catch (GuzzleException $e) {
             echo "::warning::ChecksClient error: {$e->getMessage()}\n";
+
             return false;
         }
     }

--- a/app/GitHub/CommentsClient.php
+++ b/app/GitHub/CommentsClient.php
@@ -69,6 +69,7 @@ class CommentsClient
             return true;
         } catch (GuzzleException $e) {
             echo "::warning::Failed to post/update PR comment: {$e->getMessage()}\n";
+
             return false;
         }
     }
@@ -106,6 +107,7 @@ class CommentsClient
         }
 
         $event = json_decode(file_get_contents($eventPath), true);
+
         return $event['pull_request']['number'] ?? null;
     }
 }

--- a/app/Services/CoverageReporter.php
+++ b/app/Services/CoverageReporter.php
@@ -33,13 +33,16 @@ class CoverageReporter
 
         $metrics = $xml->project->metrics ?? null;
         if ($metrics === null) {
-            throw new \RuntimeException("Invalid clover format: missing project metrics");
+            throw new \RuntimeException('Invalid clover format: missing project metrics');
         }
 
         $files = [];
         foreach ($xml->project->package ?? [] as $package) {
             foreach ($package->file ?? [] as $file) {
-                $files[] = $this->parseFile($file);
+                $parsed = $this->parseFile($file);
+                if ($parsed !== null) {
+                    $files[] = $parsed;
+                }
             }
         }
 
@@ -49,11 +52,11 @@ class CoverageReporter
         ];
     }
 
-    private function parseFile(SimpleXMLElement $file): array
+    private function parseFile(SimpleXMLElement $file): ?array
     {
         $metrics = $file->metrics ?? null;
         if ($metrics === null) {
-            return [];
+            return null;
         }
 
         $fileName = (string) $file['name'];
@@ -127,7 +130,7 @@ class CoverageReporter
                 $uncoveredCount = count($file['uncovered_lines']);
                 $uncoveredPreview = $uncoveredCount > 0 ? implode(', ', array_slice($file['uncovered_lines'], 0, 5)) : 'None';
                 if ($uncoveredCount > 5) {
-                    $uncoveredPreview .= "... (+".($uncoveredCount - 5)." more)";
+                    $uncoveredPreview .= '... (+'.($uncoveredCount - 5).' more)';
                 }
                 $markdown .= "| `{$fileName}` | {$coverage}% | {$uncoveredPreview} |\n";
             }

--- a/app/Services/PestOutputParser.php
+++ b/app/Services/PestOutputParser.php
@@ -36,7 +36,7 @@ final class PestOutputParser
         $location = preg_match('/at\s+(\S+:\d+)/', $body, $m) ? " ({$m[1]})" : '';
         $message = $this->extractAssertionMessage($body);
 
-        return $name . $location . $message;
+        return $name.$location.$message;
     }
 
     private function extractAssertionMessage(string $body): string

--- a/app/Stages/TechnicalGate.php
+++ b/app/Stages/TechnicalGate.php
@@ -10,7 +10,7 @@ use App\Verdict;
 final class TechnicalGate
 {
     /**
-     * @param array<CheckInterface> $checks
+     * @param  array<CheckInterface>  $checks
      */
     public function __construct(
         private readonly array $checks,

--- a/app/Verdict.php
+++ b/app/Verdict.php
@@ -7,14 +7,13 @@ namespace App;
 final readonly class Verdict
 {
     /**
-     * @param array<int, string> $failures
+     * @param  array<int, string>  $failures
      */
     private function __construct(
         private string $status,
         private string $reason,
         private array $failures = []
-    ) {
-    }
+    ) {}
 
     public static function approved(string $reason): self
     {

--- a/tests/Feature/RunCommandTest.php
+++ b/tests/Feature/RunCommandTest.php
@@ -10,12 +10,12 @@ use App\Commands\TestsCommand;
 describe('Gate Commands', function () {
     describe('TestsCommand', function () {
         it('has the correct signature', function () {
-            $command = new TestsCommand();
+            $command = new TestsCommand;
             expect($command->getName())->toBe('tests');
         });
 
         it('has coverage option with default of 80', function () {
-            $command = new TestsCommand();
+            $command = new TestsCommand;
             $definition = $command->getDefinition();
 
             expect($definition->hasOption('coverage'))->toBeTrue();
@@ -23,43 +23,43 @@ describe('Gate Commands', function () {
         });
 
         it('has token option', function () {
-            $command = new TestsCommand();
+            $command = new TestsCommand;
             expect($command->getDefinition()->hasOption('token'))->toBeTrue();
         });
     });
 
     describe('SecurityCommand', function () {
         it('has the correct signature', function () {
-            $command = new SecurityCommand();
+            $command = new SecurityCommand;
             expect($command->getName())->toBe('security');
         });
 
         it('has token option', function () {
-            $command = new SecurityCommand();
+            $command = new SecurityCommand;
             expect($command->getDefinition()->hasOption('token'))->toBeTrue();
         });
     });
 
     describe('SyntaxCommand', function () {
         it('has the correct signature', function () {
-            $command = new SyntaxCommand();
+            $command = new SyntaxCommand;
             expect($command->getName())->toBe('syntax');
         });
 
         it('has token option', function () {
-            $command = new SyntaxCommand();
+            $command = new SyntaxCommand;
             expect($command->getDefinition()->hasOption('token'))->toBeTrue();
         });
     });
 
     describe('CertifyCommand', function () {
         it('has the correct signature', function () {
-            $command = new CertifyCommand();
+            $command = new CertifyCommand;
             expect($command->getName())->toBe('certify');
         });
 
         it('has coverage option with default of 80', function () {
-            $command = new CertifyCommand();
+            $command = new CertifyCommand;
             $definition = $command->getDefinition();
 
             expect($definition->hasOption('coverage'))->toBeTrue();
@@ -67,12 +67,12 @@ describe('Gate Commands', function () {
         });
 
         it('has token option', function () {
-            $command = new CertifyCommand();
+            $command = new CertifyCommand;
             expect($command->getDefinition()->hasOption('token'))->toBeTrue();
         });
 
         it('has compact option', function () {
-            $command = new CertifyCommand();
+            $command = new CertifyCommand;
             $definition = $command->getDefinition();
 
             expect($definition->hasOption('compact'))->toBeTrue();

--- a/tests/Feature/TechnicalGateTest.php
+++ b/tests/Feature/TechnicalGateTest.php
@@ -2,16 +2,21 @@
 
 declare(strict_types=1);
 
-use App\Stages\TechnicalGate;
 use App\Checks\CheckInterface;
 use App\Checks\CheckResult;
-use App\Verdict;
+use App\Stages\TechnicalGate;
 
 describe('TechnicalGate', function () {
     it('returns approved verdict when all checks pass', function () {
-        $passingCheck = new class implements CheckInterface {
-            public function name(): string { return 'Mock Check'; }
-            public function run(string $workingDirectory): CheckResult {
+        $passingCheck = new class implements CheckInterface
+        {
+            public function name(): string
+            {
+                return 'Mock Check';
+            }
+
+            public function run(string $workingDirectory): CheckResult
+            {
                 return CheckResult::pass('All good');
             }
         };
@@ -24,9 +29,15 @@ describe('TechnicalGate', function () {
     });
 
     it('returns rejected verdict when a check fails', function () {
-        $failingCheck = new class implements CheckInterface {
-            public function name(): string { return 'Failing Check'; }
-            public function run(string $workingDirectory): CheckResult {
+        $failingCheck = new class implements CheckInterface
+        {
+            public function name(): string
+            {
+                return 'Failing Check';
+            }
+
+            public function run(string $workingDirectory): CheckResult
+            {
                 return CheckResult::fail('Something went wrong', ['detail 1']);
             }
         };
@@ -40,15 +51,27 @@ describe('TechnicalGate', function () {
     });
 
     it('aggregates multiple failures into single verdict', function () {
-        $failingCheck1 = new class implements CheckInterface {
-            public function name(): string { return 'Check 1'; }
-            public function run(string $workingDirectory): CheckResult {
+        $failingCheck1 = new class implements CheckInterface
+        {
+            public function name(): string
+            {
+                return 'Check 1';
+            }
+
+            public function run(string $workingDirectory): CheckResult
+            {
                 return CheckResult::fail('First failure');
             }
         };
-        $failingCheck2 = new class implements CheckInterface {
-            public function name(): string { return 'Check 2'; }
-            public function run(string $workingDirectory): CheckResult {
+        $failingCheck2 = new class implements CheckInterface
+        {
+            public function name(): string
+            {
+                return 'Check 2';
+            }
+
+            public function run(string $workingDirectory): CheckResult
+            {
                 return CheckResult::fail('Second failure');
             }
         };
@@ -63,19 +86,35 @@ describe('TechnicalGate', function () {
     it('runs all checks even if some fail', function () {
         $checkRuns = [];
 
-        $failingCheck = new class($checkRuns) implements CheckInterface {
+        $failingCheck = new class($checkRuns) implements CheckInterface
+        {
             public function __construct(private array &$runs) {}
-            public function name(): string { return 'Failing'; }
-            public function run(string $workingDirectory): CheckResult {
+
+            public function name(): string
+            {
+                return 'Failing';
+            }
+
+            public function run(string $workingDirectory): CheckResult
+            {
                 $this->runs[] = 'failing';
+
                 return CheckResult::fail('Failed');
             }
         };
-        $passingCheck = new class($checkRuns) implements CheckInterface {
+        $passingCheck = new class($checkRuns) implements CheckInterface
+        {
             public function __construct(private array &$runs) {}
-            public function name(): string { return 'Passing'; }
-            public function run(string $workingDirectory): CheckResult {
+
+            public function name(): string
+            {
+                return 'Passing';
+            }
+
+            public function run(string $workingDirectory): CheckResult
+            {
                 $this->runs[] = 'passing';
+
                 return CheckResult::pass('Passed');
             }
         };
@@ -87,9 +126,15 @@ describe('TechnicalGate', function () {
     });
 
     it('includes check name in failure messages', function () {
-        $failingCheck = new class implements CheckInterface {
-            public function name(): string { return 'Security Audit'; }
-            public function run(string $workingDirectory): CheckResult {
+        $failingCheck = new class implements CheckInterface
+        {
+            public function name(): string
+            {
+                return 'Security Audit';
+            }
+
+            public function run(string $workingDirectory): CheckResult
+            {
                 return CheckResult::fail('Vulnerabilities found');
             }
         };

--- a/tests/Unit/Checks/PestSyntaxValidatorTest.php
+++ b/tests/Unit/Checks/PestSyntaxValidatorTest.php
@@ -3,26 +3,25 @@
 declare(strict_types=1);
 
 use App\Checks\PestSyntaxValidator;
-use App\Checks\CheckResult;
 
 describe('PestSyntaxValidator', function () {
     it('has a descriptive name', function () {
-        $validator = new PestSyntaxValidator();
+        $validator = new PestSyntaxValidator;
         expect($validator->name())->toBe('Pest Syntax');
     });
 
     it('implements CheckInterface', function () {
-        $validator = new PestSyntaxValidator();
+        $validator = new PestSyntaxValidator;
         expect($validator)->toBeInstanceOf(\App\Checks\CheckInterface::class);
     });
 
     it('passes when test files use describe/it blocks', function () {
-        $validator = new PestSyntaxValidator();
+        $validator = new PestSyntaxValidator;
 
         // Create a temp test file with valid syntax
-        $tempDir = sys_get_temp_dir() . '/gate-test-' . uniqid();
-        mkdir($tempDir . '/tests', recursive: true);
-        file_put_contents($tempDir . '/tests/ExampleTest.php', <<<'PHP'
+        $tempDir = sys_get_temp_dir().'/gate-test-'.uniqid();
+        mkdir($tempDir.'/tests', recursive: true);
+        file_put_contents($tempDir.'/tests/ExampleTest.php', <<<'PHP'
 <?php
 describe('Example', function () {
     it('works', function () {
@@ -36,13 +35,13 @@ PHP);
         expect($result->passed)->toBeTrue();
 
         // Cleanup
-        unlink($tempDir . '/tests/ExampleTest.php');
-        rmdir($tempDir . '/tests');
+        unlink($tempDir.'/tests/ExampleTest.php');
+        rmdir($tempDir.'/tests');
         rmdir($tempDir);
     });
 
     it('passes when no tests directory exists', function () {
-        $validator = new PestSyntaxValidator();
+        $validator = new PestSyntaxValidator;
 
         $tempDir = sys_get_temp_dir().'/gate-test-'.uniqid();
         mkdir($tempDir);
@@ -56,14 +55,14 @@ PHP);
     });
 
     it('fails when test files use test() function', function () {
-        $validator = new PestSyntaxValidator();
+        $validator = new PestSyntaxValidator;
 
         // Create a temp test file with invalid syntax
         // Note: Using concatenation to avoid triggering our own syntax validator
-        $tempDir = sys_get_temp_dir() . '/gate-test-' . uniqid();
-        mkdir($tempDir . '/tests', recursive: true);
-        $badContent = "<?php\n" . "test('something works', function () {\n    expect(true)->toBeTrue();\n});";
-        file_put_contents($tempDir . '/tests/BadTest.php', $badContent);
+        $tempDir = sys_get_temp_dir().'/gate-test-'.uniqid();
+        mkdir($tempDir.'/tests', recursive: true);
+        $badContent = "<?php\n"."test('something works', function () {\n    expect(true)->toBeTrue();\n});";
+        file_put_contents($tempDir.'/tests/BadTest.php', $badContent);
 
         $result = $validator->run($tempDir);
 
@@ -71,8 +70,8 @@ PHP);
         expect($result->message)->toContain('test() function');
 
         // Cleanup
-        unlink($tempDir . '/tests/BadTest.php');
-        rmdir($tempDir . '/tests');
+        unlink($tempDir.'/tests/BadTest.php');
+        rmdir($tempDir.'/tests');
         rmdir($tempDir);
     });
 });

--- a/tests/Unit/Checks/SecurityScannerTest.php
+++ b/tests/Unit/Checks/SecurityScannerTest.php
@@ -8,12 +8,12 @@ use App\Contracts\ProcessRunner;
 
 describe('SecurityScanner', function () {
     it('has a descriptive name', function () {
-        $scanner = new SecurityScanner();
+        $scanner = new SecurityScanner;
         expect($scanner->name())->toBe('Security Audit');
     });
 
     it('implements CheckInterface', function () {
-        $scanner = new SecurityScanner();
+        $scanner = new SecurityScanner;
         expect($scanner)->toBeInstanceOf(\App\Checks\CheckInterface::class);
     });
 

--- a/tests/Unit/Checks/TestRunnerTest.php
+++ b/tests/Unit/Checks/TestRunnerTest.php
@@ -29,7 +29,7 @@ describe('TestRunner', function () {
 
         $runner = new TestRunner(
             coverageThreshold: 100,
-            parser: new PestOutputParser(),
+            parser: new PestOutputParser,
             processRunner: $mockRunner,
         );
 
@@ -57,7 +57,7 @@ OUTPUT,
 
         $runner = new TestRunner(
             coverageThreshold: 100,
-            parser: new PestOutputParser(),
+            parser: new PestOutputParser,
             processRunner: $mockRunner,
         );
 
@@ -79,7 +79,7 @@ OUTPUT,
 
         $runner = new TestRunner(
             coverageThreshold: 100,
-            parser: new PestOutputParser(),
+            parser: new PestOutputParser,
             processRunner: $mockRunner,
         );
 
@@ -111,7 +111,7 @@ OUTPUT,
 
         $runner = new TestRunner(
             coverageThreshold: 100,
-            parser: new PestOutputParser(),
+            parser: new PestOutputParser,
             processRunner: $mockRunner,
         );
 
@@ -136,7 +136,7 @@ OUTPUT,
 
         $runner = new TestRunner(
             coverageThreshold: 80,
-            parser: new PestOutputParser(),
+            parser: new PestOutputParser,
             processRunner: $mockRunner,
         );
 
@@ -154,7 +154,7 @@ OUTPUT,
 
         $runner = new TestRunner(
             coverageThreshold: 100,
-            parser: new PestOutputParser(),
+            parser: new PestOutputParser,
             processRunner: $mockRunner,
         );
 
@@ -182,7 +182,7 @@ OUTPUT,
 
         $runner = new TestRunner(
             coverageThreshold: 100,
-            parser: new PestOutputParser(),
+            parser: new PestOutputParser,
             processRunner: $mockRunner,
         );
 
@@ -213,7 +213,7 @@ OUTPUT,
 
             $runner = new TestRunner(
                 coverageThreshold: 100,
-                parser: new PestOutputParser(),
+                parser: new PestOutputParser,
                 processRunner: $mockRunner,
             );
 
@@ -235,7 +235,7 @@ OUTPUT,
 
             $runner = new TestRunner(
                 coverageThreshold: 100,
-                parser: new PestOutputParser(),
+                parser: new PestOutputParser,
                 processRunner: $mockRunner,
             );
 
@@ -249,9 +249,9 @@ OUTPUT,
             putenv('GITHUB_TOKEN=');
 
             // Create a temp coverage.xml to pass the file_exists check
-            $tempDir = sys_get_temp_dir() . '/test_coverage_' . uniqid();
+            $tempDir = sys_get_temp_dir().'/test_coverage_'.uniqid();
             mkdir($tempDir);
-            file_put_contents($tempDir . '/coverage.xml', '<?xml version="1.0"?><coverage><project><metrics/></project></coverage>');
+            file_put_contents($tempDir.'/coverage.xml', '<?xml version="1.0"?><coverage><project><metrics/></project></coverage>');
 
             $mockRunner = mock(ProcessRunner::class);
             $mockRunner->shouldReceive('run')
@@ -263,7 +263,7 @@ OUTPUT,
 
             $runner = new TestRunner(
                 coverageThreshold: 100,
-                parser: new PestOutputParser(),
+                parser: new PestOutputParser,
                 processRunner: $mockRunner,
             );
 
@@ -271,7 +271,7 @@ OUTPUT,
             expect($result->passed)->toBeTrue();
 
             // Cleanup
-            unlink($tempDir . '/coverage.xml');
+            unlink($tempDir.'/coverage.xml');
             rmdir($tempDir);
         });
 
@@ -279,9 +279,9 @@ OUTPUT,
             putenv('COVERAGE_COMMENT=true');
 
             // Create temp dir with coverage.xml
-            $tempDir = sys_get_temp_dir() . '/test_coverage_di_' . uniqid();
+            $tempDir = sys_get_temp_dir().'/test_coverage_di_'.uniqid();
             mkdir($tempDir);
-            file_put_contents($tempDir . '/coverage.xml', '<?xml version="1.0"?><coverage><project><metrics statements="100" coveredstatements="100" elements="100" coveredelements="100"/></project></coverage>');
+            file_put_contents($tempDir.'/coverage.xml', '<?xml version="1.0"?><coverage><project><metrics statements="100" coveredstatements="100" elements="100" coveredelements="100"/></project></coverage>');
 
             $mockRunner = mock(ProcessRunner::class);
             $mockRunner->shouldReceive('run')
@@ -299,13 +299,13 @@ OUTPUT,
             // Mock CoverageReporter
             $mockReporter = mock(\App\Services\CoverageReporter::class);
             $mockReporter->shouldReceive('generatePRComment')
-                ->with($tempDir . '/coverage.xml')
+                ->with($tempDir.'/coverage.xml')
                 ->once()
                 ->andReturn('Coverage: 100%');
 
             $runner = new TestRunner(
                 coverageThreshold: 100,
-                parser: new PestOutputParser(),
+                parser: new PestOutputParser,
                 processRunner: $mockRunner,
             );
 
@@ -316,7 +316,7 @@ OUTPUT,
             expect($result->passed)->toBeTrue();
 
             // Cleanup
-            unlink($tempDir . '/coverage.xml');
+            unlink($tempDir.'/coverage.xml');
             rmdir($tempDir);
         });
 
@@ -324,9 +324,9 @@ OUTPUT,
             putenv('COVERAGE_COMMENT=true');
 
             // Create temp dir with coverage.xml
-            $tempDir = sys_get_temp_dir() . '/test_coverage_unavail_' . uniqid();
+            $tempDir = sys_get_temp_dir().'/test_coverage_unavail_'.uniqid();
             mkdir($tempDir);
-            file_put_contents($tempDir . '/coverage.xml', '<?xml version="1.0"?><coverage><project><metrics/></project></coverage>');
+            file_put_contents($tempDir.'/coverage.xml', '<?xml version="1.0"?><coverage><project><metrics/></project></coverage>');
 
             $mockRunner = mock(ProcessRunner::class);
             $mockRunner->shouldReceive('run')
@@ -345,7 +345,7 @@ OUTPUT,
 
             $runner = new TestRunner(
                 coverageThreshold: 100,
-                parser: new PestOutputParser(),
+                parser: new PestOutputParser,
                 processRunner: $mockRunner,
             );
 
@@ -356,7 +356,7 @@ OUTPUT,
             expect($result->passed)->toBeTrue();
 
             // Cleanup
-            unlink($tempDir . '/coverage.xml');
+            unlink($tempDir.'/coverage.xml');
             rmdir($tempDir);
         });
 
@@ -364,9 +364,9 @@ OUTPUT,
             putenv('COVERAGE_COMMENT=true');
 
             // Create temp dir with coverage.xml
-            $tempDir = sys_get_temp_dir() . '/test_coverage_error_' . uniqid();
+            $tempDir = sys_get_temp_dir().'/test_coverage_error_'.uniqid();
             mkdir($tempDir);
-            file_put_contents($tempDir . '/coverage.xml', '<?xml version="1.0"?><coverage><project><metrics statements="100" coveredstatements="100" elements="100" coveredelements="100"/></project></coverage>');
+            file_put_contents($tempDir.'/coverage.xml', '<?xml version="1.0"?><coverage><project><metrics statements="100" coveredstatements="100" elements="100" coveredelements="100"/></project></coverage>');
 
             $mockRunner = mock(ProcessRunner::class);
             $mockRunner->shouldReceive('run')
@@ -387,7 +387,7 @@ OUTPUT,
 
             $runner = new TestRunner(
                 coverageThreshold: 100,
-                parser: new PestOutputParser(),
+                parser: new PestOutputParser,
                 processRunner: $mockRunner,
             );
 
@@ -401,7 +401,7 @@ OUTPUT,
                 ->and($output)->toContain('::debug::Coverage comment failed');
 
             // Cleanup
-            unlink($tempDir . '/coverage.xml');
+            unlink($tempDir.'/coverage.xml');
             rmdir($tempDir);
         });
     });
@@ -428,7 +428,7 @@ OUTPUT,
 
         $runner = new TestRunner(
             coverageThreshold: 100,
-            parser: new PestOutputParser(),
+            parser: new PestOutputParser,
             processRunner: $mockRunner,
         );
 

--- a/tests/Unit/Commands/CertifyCommandTest.php
+++ b/tests/Unit/Commands/CertifyCommandTest.php
@@ -14,7 +14,7 @@ use GuzzleHttp\Psr7\Response;
 beforeEach(function () {
     // Helper to create a command with mocks
     $this->createCommand = function (array $checks, ChecksClient $checksClient) {
-        $command = new CertifyCommand();
+        $command = new CertifyCommand;
         $command->withMocks($checks, $checksClient);
         app()->singleton(CertifyCommand::class, fn () => $command);
     };

--- a/tests/Unit/Commands/SecurityCommandTest.php
+++ b/tests/Unit/Commands/SecurityCommandTest.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Psr7\Response;
 
 beforeEach(function () {
     $this->createCommand = function (CheckInterface $check, ChecksClient $checksClient) {
-        $command = new SecurityCommand();
+        $command = new SecurityCommand;
         $command->withMocks($check, $checksClient);
         app()->singleton(SecurityCommand::class, fn () => $command);
     };

--- a/tests/Unit/Commands/SyntaxCommandTest.php
+++ b/tests/Unit/Commands/SyntaxCommandTest.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Psr7\Response;
 
 beforeEach(function () {
     $this->createCommand = function (CheckInterface $check, ChecksClient $checksClient) {
-        $command = new SyntaxCommand();
+        $command = new SyntaxCommand;
         $command->withMocks($check, $checksClient);
         app()->singleton(SyntaxCommand::class, fn () => $command);
     };

--- a/tests/Unit/Commands/TestsCommandTest.php
+++ b/tests/Unit/Commands/TestsCommandTest.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Psr7\Response;
 
 beforeEach(function () {
     $this->createCommand = function (CheckInterface $check, ChecksClient $checksClient) {
-        $command = new TestsCommand();
+        $command = new TestsCommand;
         $command->withMocks($check, $checksClient);
         app()->singleton(TestsCommand::class, fn () => $command);
     };

--- a/tests/Unit/GitHub/ChecksClientTest.php
+++ b/tests/Unit/GitHub/ChecksClientTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use App\GitHub\ChecksClient;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 
 describe('ChecksClient', function () {
     describe('extractPRNumber', function () {

--- a/tests/Unit/GitHub/CommentsClientTest.php
+++ b/tests/Unit/GitHub/CommentsClientTest.php
@@ -63,7 +63,7 @@ describe('CommentsClient', function () {
         });
 
         it('returns null when event JSON has no PR number', function () {
-            $tempFile = sys_get_temp_dir() . '/event_no_pr_' . uniqid() . '.json';
+            $tempFile = sys_get_temp_dir().'/event_no_pr_'.uniqid().'.json';
             file_put_contents($tempFile, json_encode(['action' => 'opened']));
             putenv("GITHUB_EVENT_PATH={$tempFile}");
 
@@ -74,7 +74,7 @@ describe('CommentsClient', function () {
         });
 
         it('extracts PR number from event JSON', function () {
-            $tempFile = sys_get_temp_dir() . '/event_' . uniqid() . '.json';
+            $tempFile = sys_get_temp_dir().'/event_'.uniqid().'.json';
             file_put_contents($tempFile, json_encode(['pull_request' => ['number' => 456]]));
             putenv("GITHUB_EVENT_PATH={$tempFile}");
 

--- a/tests/Unit/Services/CoverageReporterTest.php
+++ b/tests/Unit/Services/CoverageReporterTest.php
@@ -7,15 +7,15 @@ use App\Services\CoverageReporter;
 describe('CoverageReporter', function () {
     describe('parseClover', function () {
         it('throws exception when file not found', function () {
-            $reporter = new CoverageReporter();
+            $reporter = new CoverageReporter;
             $reporter->parseClover('/nonexistent/path.xml');
         })->throws(RuntimeException::class, 'Coverage file not found');
 
         it('throws exception when file contains invalid XML', function () {
-            $tempFile = sys_get_temp_dir() . '/invalid_xml_' . uniqid() . '.xml';
+            $tempFile = sys_get_temp_dir().'/invalid_xml_'.uniqid().'.xml';
             file_put_contents($tempFile, 'not valid xml');
 
-            $reporter = new CoverageReporter();
+            $reporter = new CoverageReporter;
             try {
                 $reporter->parseClover($tempFile);
             } finally {
@@ -25,10 +25,10 @@ describe('CoverageReporter', function () {
 
         it('throws exception when clover format is missing project metrics', function () {
             $xml = '<?xml version="1.0"?><coverage><project></project></coverage>';
-            $tempFile = sys_get_temp_dir() . '/no_metrics_' . uniqid() . '.xml';
+            $tempFile = sys_get_temp_dir().'/no_metrics_'.uniqid().'.xml';
             file_put_contents($tempFile, $xml);
 
-            $reporter = new CoverageReporter();
+            $reporter = new CoverageReporter;
             try {
                 $reporter->parseClover($tempFile);
             } finally {
@@ -54,10 +54,10 @@ describe('CoverageReporter', function () {
 </coverage>
 XML;
 
-            $tempFile = sys_get_temp_dir() . '/valid_clover_' . uniqid() . '.xml';
+            $tempFile = sys_get_temp_dir().'/valid_clover_'.uniqid().'.xml';
             file_put_contents($tempFile, $xml);
 
-            $reporter = new CoverageReporter();
+            $reporter = new CoverageReporter;
             $result = $reporter->parseClover($tempFile);
 
             expect($result['total']['statements'])->toBe(100)
@@ -70,7 +70,7 @@ XML;
             unlink($tempFile);
         });
 
-        it('handles file without metrics', function () {
+        it('skips files without metrics entirely', function () {
             $xml = <<<'XML'
 <?xml version="1.0"?>
 <coverage>
@@ -84,13 +84,46 @@ XML;
 </coverage>
 XML;
 
-            $tempFile = sys_get_temp_dir() . '/no_file_metrics_' . uniqid() . '.xml';
+            $tempFile = sys_get_temp_dir().'/no_file_metrics_'.uniqid().'.xml';
             file_put_contents($tempFile, $xml);
 
-            $reporter = new CoverageReporter();
+            $reporter = new CoverageReporter;
             $result = $reporter->parseClover($tempFile);
 
-            expect($result['files'][0])->toBeEmpty();
+            expect($result['files'])->toBeEmpty();
+
+            unlink($tempFile);
+        });
+
+        it('includes only files with metrics when mixed with files without', function () {
+            $xml = <<<'XML'
+<?xml version="1.0"?>
+<coverage>
+  <project timestamp="1234567890">
+    <metrics statements="100" coveredstatements="80" elements="120" coveredelements="96"/>
+    <package name="App">
+      <file name="/path/to/NoMetrics.php">
+      </file>
+      <file name="/path/to/WithMetrics.php">
+        <metrics statements="50" coveredstatements="40" elements="60" coveredelements="48"/>
+        <line num="10" type="stmt" count="1"/>
+      </file>
+      <file name="/path/to/AnotherNoMetrics.php">
+      </file>
+    </package>
+  </project>
+</coverage>
+XML;
+
+            $tempFile = sys_get_temp_dir().'/mixed_metrics_'.uniqid().'.xml';
+            file_put_contents($tempFile, $xml);
+
+            $reporter = new CoverageReporter;
+            $result = $reporter->parseClover($tempFile);
+
+            expect($result['files'])->toHaveCount(1)
+                ->and($result['files'][0]['name'])->toBe('/path/to/WithMetrics.php')
+                ->and($result['files'][0]['metrics']['statements'])->toBe(50);
 
             unlink($tempFile);
         });
@@ -105,10 +138,10 @@ XML;
 </coverage>
 XML;
 
-            $tempFile = sys_get_temp_dir() . '/zero_stmts_' . uniqid() . '.xml';
+            $tempFile = sys_get_temp_dir().'/zero_stmts_'.uniqid().'.xml';
             file_put_contents($tempFile, $xml);
 
-            $reporter = new CoverageReporter();
+            $reporter = new CoverageReporter;
             $result = $reporter->parseClover($tempFile);
 
             expect($result['total']['coverage_percent'])->toBe(0.0);
@@ -128,7 +161,7 @@ XML;
 </coverage>
 XML;
 
-            $tempFile = sys_get_temp_dir() . '/full_coverage_' . uniqid() . '.xml';
+            $tempFile = sys_get_temp_dir().'/full_coverage_'.uniqid().'.xml';
             file_put_contents($tempFile, $xml);
 
             $reporter = new CoverageReporter(100);
@@ -164,7 +197,7 @@ XML;
 </coverage>
 XML;
 
-            $tempFile = sys_get_temp_dir() . '/low_coverage_' . uniqid() . '.xml';
+            $tempFile = sys_get_temp_dir().'/low_coverage_'.uniqid().'.xml';
             file_put_contents($tempFile, $xml);
 
             $reporter = new CoverageReporter(80);
@@ -188,8 +221,8 @@ XML;
 </coverage>
 XML;
 
-            $currentFile = sys_get_temp_dir() . '/current_' . uniqid() . '.xml';
-            $baseFile = sys_get_temp_dir() . '/base_' . uniqid() . '.xml';
+            $currentFile = sys_get_temp_dir().'/current_'.uniqid().'.xml';
+            $baseFile = sys_get_temp_dir().'/base_'.uniqid().'.xml';
             file_put_contents($currentFile, $xml);
             file_put_contents($baseFile, $xml);
 

--- a/tests/Unit/Services/PestOutputParserTest.php
+++ b/tests/Unit/Services/PestOutputParserTest.php
@@ -7,19 +7,19 @@ use App\Services\PestOutputParser;
 describe('PestOutputParser', function () {
     describe('parseTestCount', function () {
         it('parses test count from output', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Tests:  42 passed (8 assertions)';
             expect($parser->parseTestCount($output))->toBe(42);
         });
 
         it('returns 0 when no test count found', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'No tests found';
             expect($parser->parseTestCount($output))->toBe(0);
         });
 
         it('handles single digit test count', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Tests:  3 passed';
             expect($parser->parseTestCount($output))->toBe(3);
         });
@@ -27,25 +27,25 @@ describe('PestOutputParser', function () {
 
     describe('parseCoverage', function () {
         it('parses coverage percentage', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Total:  95.50%';
             expect($parser->parseCoverage($output))->toBe(95.5);
         });
 
         it('returns null when no coverage found', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Tests:  5 passed';
             expect($parser->parseCoverage($output))->toBeNull();
         });
 
         it('parses 100% coverage', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Total:  100.00%';
             expect($parser->parseCoverage($output))->toBe(100.0);
         });
 
         it('parses integer coverage', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Total:  80%';
             expect($parser->parseCoverage($output))->toBe(80.0);
         });
@@ -53,7 +53,7 @@ describe('PestOutputParser', function () {
 
     describe('parseFailures', function () {
         it('extracts failures with location and message', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
 ⨯ Tests\Unit\FooTest → it does something  0.5s
     Expected true to be false.
@@ -68,7 +68,7 @@ OUTPUT;
         });
 
         it('extracts multiple failures', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
 ⨯ Tests\Unit\FooTest → first test  0.1s
     First assertion failed.
@@ -86,7 +86,7 @@ OUTPUT;
         });
 
         it('handles failures without location', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
 ⨯ Tests\Unit\FooTest → it fails  0.5s
     Some error occurred.
@@ -99,7 +99,7 @@ OUTPUT;
         });
 
         it('handles failures without message', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
 ⨯ Tests\Unit\FooTest → it fails  0.5s
     at tests/Unit/FooTest.php:42
@@ -112,7 +112,7 @@ OUTPUT;
         });
 
         it('strips timing from test name', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
 ⨯ Tests\Unit\FooTest → it does something  1.23s
     Error message.
@@ -123,13 +123,13 @@ OUTPUT;
         });
 
         it('returns empty array when no failures', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Tests:  5 passed';
             expect($parser->parseFailures($output))->toBe([]);
         });
 
         it('handles cross marker', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
 ✗ Tests\Unit\FooTest → it fails  0.5s
     Error message.
@@ -142,19 +142,19 @@ OUTPUT;
 
     describe('isCoverageBelowThreshold', function () {
         it('detects coverage below threshold', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'FAIL  Code coverage below expected  100.0 %, currently  89.50 %.';
             expect($parser->isCoverageBelowThreshold($output))->toBe(89.5);
         });
 
         it('returns null when coverage meets threshold', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Total:  100.00%';
             expect($parser->isCoverageBelowThreshold($output))->toBeNull();
         });
 
         it('returns null when no coverage info', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Tests:  5 passed';
             expect($parser->isCoverageBelowThreshold($output))->toBeNull();
         });
@@ -162,7 +162,7 @@ OUTPUT;
 
     describe('parseFileCoverage', function () {
         it('extracts files below threshold', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
   App/Services/FooService .............. 85.0%
   App/Services/BarService .............. 92.5%
@@ -177,7 +177,7 @@ OUTPUT;
         });
 
         it('excludes Total line', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
   App/Services/FooService .............. 85.0%
   Total ................................ 85.0%
@@ -189,7 +189,7 @@ OUTPUT;
         });
 
         it('returns empty array when all files meet threshold', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
   App/Services/FooService .............. 100.0%
   App/Services/BarService .............. 100.0%
@@ -201,7 +201,7 @@ OUTPUT;
         });
 
         it('respects custom threshold', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = <<<'OUTPUT'
   App/Services/FooService .............. 75.0%
   App/Services/BarService .............. 85.0%
@@ -214,7 +214,7 @@ OUTPUT;
         });
 
         it('returns empty array when no coverage output', function () {
-            $parser = new PestOutputParser();
+            $parser = new PestOutputParser;
             $output = 'Tests:  5 passed';
 
             expect($parser->parseFileCoverage($output, 100.0))->toBeEmpty();

--- a/tests/Unit/Services/SymfonyProcessRunnerTest.php
+++ b/tests/Unit/Services/SymfonyProcessRunnerTest.php
@@ -8,7 +8,7 @@ use App\Services\SymfonyProcessRunner;
 describe('SymfonyProcessRunner', function () {
     describe('run', function () {
         it('returns successful result for successful command', function () {
-            $runner = new SymfonyProcessRunner();
+            $runner = new SymfonyProcessRunner;
             $result = $runner->run(['echo', 'hello'], sys_get_temp_dir());
 
             expect($result)->toBeInstanceOf(ProcessResult::class);
@@ -18,7 +18,7 @@ describe('SymfonyProcessRunner', function () {
         });
 
         it('returns failed result for failing command', function () {
-            $runner = new SymfonyProcessRunner();
+            $runner = new SymfonyProcessRunner;
             $result = $runner->run(['false'], sys_get_temp_dir());
 
             expect($result)->toBeInstanceOf(ProcessResult::class);
@@ -27,7 +27,7 @@ describe('SymfonyProcessRunner', function () {
         });
 
         it('captures stderr in output', function () {
-            $runner = new SymfonyProcessRunner();
+            $runner = new SymfonyProcessRunner;
             $result = $runner->run(['ls', '/nonexistent_directory_12345'], sys_get_temp_dir());
 
             expect($result->successful)->toBeFalse();
@@ -36,7 +36,7 @@ describe('SymfonyProcessRunner', function () {
 
         it('respects working directory', function () {
             $tmpDir = sys_get_temp_dir();
-            $runner = new SymfonyProcessRunner();
+            $runner = new SymfonyProcessRunner;
             $result = $runner->run(['pwd'], $tmpDir);
 
             expect($result->successful)->toBeTrue();
@@ -45,7 +45,7 @@ describe('SymfonyProcessRunner', function () {
         });
 
         it('applies timeout parameter', function () {
-            $runner = new SymfonyProcessRunner();
+            $runner = new SymfonyProcessRunner;
             // This should complete quickly, we're just testing the timeout parameter is accepted
             $result = $runner->run(['echo', 'fast'], sys_get_temp_dir(), timeout: 5);
 


### PR DESCRIPTION
## Summary

Fixes #23 - Files without metrics are now skipped entirely instead of being added as empty arrays to the files list.

## Changes

1. Modified `parseFile()` to return `?array` (nullable) instead of `array`
2. Returns `null` when file has no metrics element (previously returned `[]`)
3. Updated `parseClover()` to filter out null values when building files array
4. Enhanced test coverage to verify:
   - Files without metrics are skipped completely (not present in array)
   - Mixed scenarios (files with/without metrics) work correctly
   - Files array count is accurate

## Impact

- **Data Quality**: Files array no longer contains empty elements
- **Accuracy**: File counts reflect actual files with metrics
- **Consistency**: Cleaner data structure for downstream consumers
- **Backwards Compatible**: The filtering in `formatMarkdown()` was already handling this correctly

## Testing

- All existing tests pass
- Added new test: "skips files without metrics entirely"
- Added new test: "includes only files with metrics when mixed with files without"
- Test coverage remains at 100%
- Laravel Pint formatting applied

## Test Plan

- [x] Run all tests with 100% coverage: `./vendor/bin/pest --coverage --min=100`
- [x] Verify code formatting: `./vendor/bin/pint`
- [x] Confirm no regression in existing behavior
- [x] Validate new tests cover edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new branding constants to support extended security and syntax validation capabilities

* **Bug Fixes**
  * Fixed coverage report handling to properly exclude files missing metrics data

* **Style**
  * Applied code formatting improvements and standardized instantiation patterns across the codebase

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->