### PR TITLE
docs: add required workflow permissions to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,26 @@ on: [pull_request]
 jobs:
   gate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required for auto-merge
+      checks: write        # Required for check status
+      pull-requests: write # Required for PR comments
     steps:
       - uses: actions/checkout@v4
       - uses: synapse-sentinel/gate@v1
         with:
           coverage-threshold: 100
 ```
+
+### Required Permissions
+
+The Gate action requires specific workflow permissions to function properly:
+
+- `contents: write` - Enables auto-merge on approved PRs
+- `checks: write` - Allows creating check runs with status
+- `pull-requests: write` - Enables posting coverage reports and verdict comments
+
+Without these permissions, the action will run successfully but features will silently fail (e.g., no PR comments, no auto-merge).
 
 ## What It Checks
 


### PR DESCRIPTION
## Summary

Adds missing workflow permissions documentation to the Quick Start guide.

## Problem (Issue #20)

The Quick Start example didn't document required workflow permissions, causing features to silently fail:
- PR comments not appearing (needs `pull-requests: write`)
- Auto-merge not working (needs `contents: write`)  
- Check status not updating (needs `checks: write`)

This was discovered in the `knowledge` repo where Sentinel Gate ran successfully but didn't post PR comments due to missing `pull-requests: write` permission.

## Changes

1. Added `permissions` block to Quick Start workflow example
2. Added new "Required Permissions" section explaining:
   - What each permission enables
   - Impact of missing permissions
   - Why failures are silent

## Testing

Documentation-only change. Verified:
- Markdown formatting renders correctly
- Permissions syntax matches GitHub Actions schema
- Example matches fix applied in conduit-ui/knowledge

Closes #20