### PR TITLE
feat: add Laravel Zero 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.3",
         "guzzlehttp/guzzle": "^7.10",
-        "laravel-zero/framework": "^11.0",
+        "laravel-zero/framework": "^11.0|^12.0",
         "laravel/prompts": "^0.3.8",
         "symfony/process": "^7.0"
     },


### PR DESCRIPTION
## Changes
- Updated laravel-zero/framework constraint from ^11.0 to ^11.0|^12.0
- Maintains backward compatibility with Laravel Zero 11
- Enables installation in Laravel Zero 12 projects

## Testing
- [ ] Verify package installs with Laravel Zero 11
- [ ] Verify package installs with Laravel Zero 12
- [ ] Run existing tests to ensure no regressions

## Related
Allows synapse-sentinel/gate to be used in projects like jp-knowledge which use Laravel Zero ^12.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended framework support to include Laravel Zero 12.x alongside existing 11.x compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->