### PR TITLE
refactor: add Guzzle injection to AnalyzeCommand with tests

### DIFF
--- a/app/Commands/AnalyzeCommand.php
+++ b/app/Commands/AnalyzeCommand.php
@@ -17,6 +17,22 @@ class AnalyzeCommand extends Command
 
     protected $description = 'Send failures to Prefrontal Cortex for AI analysis';
 
+    private ?Client $httpClient = null;
+
+    private ?string $mockRepo = null;
+
+    private ?string $mockSha = null;
+
+    /** @internal For testing only */
+    public function withMocks(?Client $httpClient = null, ?string $repo = null, ?string $sha = null): self
+    {
+        $this->httpClient = $httpClient;
+        $this->mockRepo = $repo;
+        $this->mockSha = $sha;
+
+        return $this;
+    }
+
     public function handle(): int
     {
         $apiUrl = $this->option('api-url') ?? getenv('PREFRONTAL_API_URL') ?: 'https://prefrontal.jordanpartridge.us';
@@ -52,7 +68,7 @@ class AnalyzeCommand extends Command
         $this->info('🧠 Sending failures to Prefrontal Cortex for analysis...');
 
         try {
-            $client = new Client([
+            $client = $this->httpClient ?? new Client([
                 'base_uri' => $apiUrl,
                 'timeout' => 60,
             ]);
@@ -64,8 +80,8 @@ class AnalyzeCommand extends Command
                     'Content-Type' => 'application/json',
                 ],
                 'json' => [
-                    'repo' => $this->detectRepo(),
-                    'sha' => $this->detectSha(),
+                    'repo' => $this->mockRepo ?? $this->detectRepo(),
+                    'sha' => $this->mockSha ?? $this->detectSha(),
                     'failures' => $failures,
                 ],
             ]);

--- a/app/Commands/CertifyCommand.php
+++ b/app/Commands/CertifyCommand.php
@@ -6,7 +6,6 @@ namespace App\Commands;
 
 use App\Branding;
 use App\Checks\CheckInterface;
-use App\Checks\CheckResult;
 use App\Checks\PestSyntaxValidator;
 use App\Checks\SecurityScanner;
 use App\Checks\TestRunner;
@@ -123,7 +122,7 @@ final class CertifyCommand extends Command
             $checksClient->postCertificationComment($checkResults);
         } else {
             // Post actionable prompt with fix directions on failure
-            $assembler = new PromptAssembler();
+            $assembler = new PromptAssembler;
             $assembled = $assembler->assemble($rawOutputs);
 
             if ($assembled['prompt'] !== '') {

--- a/app/GitHub/ChecksClient.php
+++ b/app/GitHub/ChecksClient.php
@@ -89,6 +89,7 @@ final class ChecksClient
             return $data['id'] ?? null;
         } catch (GuzzleException $e) {
             $this->logError('createCheck', $e);
+
             return null;
         }
     }
@@ -119,6 +120,7 @@ final class ChecksClient
             return true;
         } catch (GuzzleException $e) {
             $this->logError('completeCheck', $e);
+
             return false;
         }
     }
@@ -155,6 +157,7 @@ final class ChecksClient
             return true;
         } catch (GuzzleException $e) {
             $this->logError('reportCheck', $e);
+
             return false;
         }
     }
@@ -199,6 +202,7 @@ MARKDOWN;
             return true;
         } catch (GuzzleException $e) {
             $this->logError('postCertificationComment', $e);
+
             return false;
         }
     }
@@ -234,6 +238,7 @@ MARKDOWN;
             return true;
         } catch (GuzzleException $e) {
             $this->logError('postActionablePrompt', $e);
+
             return false;
         }
     }

--- a/app/Services/PromptAssembler.php
+++ b/app/Services/PromptAssembler.php
@@ -22,8 +22,8 @@ final class PromptAssembler
     public function __construct()
     {
         $this->transformers = [
-            new PhpStanPromptTransformer(),
-            new TestFailurePromptTransformer(),
+            new PhpStanPromptTransformer,
+            new TestFailurePromptTransformer,
         ];
     }
 
@@ -94,7 +94,7 @@ final class PromptAssembler
     private function buildCombinedPrompt(array $failedChecks): string
     {
         $count = count($failedChecks);
-        $prompt = "# 🔧 Synapse Sentinel: {$count} check" . ($count === 1 ? '' : 's') . " need attention\n\n";
+        $prompt = "# 🔧 Synapse Sentinel: {$count} check".($count === 1 ? '' : 's')." need attention\n\n";
         $prompt .= "The following issues must be resolved before this PR can be merged:\n\n";
 
         foreach ($failedChecks as $checkName => $section) {
@@ -117,6 +117,6 @@ final class PromptAssembler
             return $text;
         }
 
-        return substr($text, 0, $maxLength) . "\n... (truncated)";
+        return substr($text, 0, $maxLength)."\n... (truncated)";
     }
 }

--- a/app/Transformers/PhpStanPromptTransformer.php
+++ b/app/Transformers/PhpStanPromptTransformer.php
@@ -115,7 +115,7 @@ final class PhpStanPromptTransformer implements PromptTransformerInterface
             $relativePath = $this->relativePath($filePath);
             $errorCount = $fileData['errors'] ?? 0;
 
-            $prompt .= "### {$relativePath} ({$errorCount} error" . ($errorCount === 1 ? '' : 's') . ")\n\n";
+            $prompt .= "### {$relativePath} ({$errorCount} error".($errorCount === 1 ? '' : 's').")\n\n";
 
             foreach ($fileData['messages'] ?? [] as $index => $message) {
                 $prompt .= $this->formatError($index + 1, $message);

--- a/app/Transformers/TestFailurePromptTransformer.php
+++ b/app/Transformers/TestFailurePromptTransformer.php
@@ -95,7 +95,6 @@ final class TestFailurePromptTransformer implements PromptTransformerInterface
     /**
      * Extract test cases from a test suite.
      *
-     * @param  \SimpleXMLElement  $suite
      * @param  array<array<string, mixed>>  $failures
      * @param  array<array<string, mixed>>  $errors
      */
@@ -246,7 +245,7 @@ final class TestFailurePromptTransformer implements PromptTransformerInterface
 
         // Truncate if too long
         if (strlen($clean) > 500) {
-            $clean = substr($clean, 0, 500) . '... (truncated)';
+            $clean = substr($clean, 0, 500).'... (truncated)';
         }
 
         return trim($clean);

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Commands\AnalyzeCommand;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+beforeEach(function () {
+    $this->failuresFile = sys_get_temp_dir().'/gate_test_failures_'.uniqid().'.json';
+
+    $this->createCommand = function (?Client $httpClient = null, ?string $repo = null, ?string $sha = null) {
+        $command = new AnalyzeCommand;
+        $command->withMocks($httpClient, $repo ?? 'owner/repo', $sha ?? 'abc123');
+        app()->singleton(AnalyzeCommand::class, fn () => $command);
+    };
+});
+
+afterEach(function () {
+    @unlink($this->failuresFile);
+    putenv('PREFRONTAL_API_TOKEN');
+    putenv('PREFRONTAL_API_URL');
+});
+
+describe('AnalyzeCommand', function () {
+    describe('validation', function () {
+        it('fails when no API token is provided', function () {
+            putenv('PREFRONTAL_API_TOKEN');
+
+            $this->artisan('analyze')
+                ->expectsOutputToContain('API token required')
+                ->assertFailed();
+        });
+
+        it('fails when no failures file is provided', function () {
+            $this->artisan('analyze', ['--api-token' => 'test-token'])
+                ->expectsOutputToContain('Failures file required')
+                ->assertFailed();
+        });
+
+        it('fails when failures file does not exist', function () {
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => '/tmp/nonexistent_file_'.uniqid().'.json',
+            ])
+                ->expectsOutputToContain('Failures file required')
+                ->assertFailed();
+        });
+
+        it('fails when failures file contains invalid JSON', function () {
+            file_put_contents($this->failuresFile, 'not valid json');
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->expectsOutputToContain('Invalid JSON')
+                ->assertFailed();
+        });
+
+        it('fails when failures file contains empty JSON array', function () {
+            file_put_contents($this->failuresFile, '[]');
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->expectsOutputToContain('Invalid JSON')
+                ->assertFailed();
+        });
+    });
+
+    describe('API interaction', function () {
+        it('sends failures to API and displays fixes', function () {
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed assertion']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $responseData = [
+                'fixes' => [
+                    ['type' => 'test', 'file' => 'tests/FooTest.php', 'suggestion' => 'Fix the assertion'],
+                ],
+                'minimal_report' => 'One fix suggested.',
+            ];
+
+            $mock = new MockHandler([
+                new Response(200, [], json_encode($responseData)),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->expectsOutputToContain('Sending failures to Prefrontal Cortex')
+                ->expectsOutputToContain('Test: tests/FooTest.php')
+                ->expectsOutputToContain('Fix the assertion')
+                ->expectsOutputToContain('One fix suggested.')
+                ->assertSuccessful();
+        });
+
+        it('handles response with empty fixes array', function () {
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed assertion']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $responseData = [
+                'fixes' => [],
+                'minimal_report' => 'No fixes needed.',
+            ];
+
+            $mock = new MockHandler([
+                new Response(200, [], json_encode($responseData)),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->expectsOutputToContain('No fixes needed.')
+                ->assertSuccessful();
+        });
+
+        it('handles fix without suggestion', function () {
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $responseData = [
+                'fixes' => [
+                    ['type' => 'style', 'file' => 'src/Foo.php'],
+                ],
+                'minimal_report' => 'Done.',
+            ];
+
+            $mock = new MockHandler([
+                new Response(200, [], json_encode($responseData)),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->expectsOutputToContain('Style: src/Foo.php')
+                ->assertSuccessful();
+        });
+
+        it('handles fix with missing type and file', function () {
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $responseData = [
+                'fixes' => [
+                    ['suggestion' => 'Try something'],
+                ],
+                'minimal_report' => 'Done.',
+            ];
+
+            $mock = new MockHandler([
+                new Response(200, [], json_encode($responseData)),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->expectsOutputToContain('Unknown: unknown')
+                ->assertSuccessful();
+        });
+
+        it('handles response without minimal_report', function () {
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $responseData = [
+                'fixes' => [],
+            ];
+
+            $mock = new MockHandler([
+                new Response(200, [], json_encode($responseData)),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->assertSuccessful();
+        });
+
+        it('fails when API returns invalid response body', function () {
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $mock = new MockHandler([
+                new Response(200, [], 'not json'),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->expectsOutputToContain('Invalid response from API')
+                ->assertFailed();
+        });
+
+        it('fails when Guzzle throws an exception', function () {
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $mock = new MockHandler([
+                new RequestException('Connection timed out', new Request('POST', '/api/gate/analyze')),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->expectsOutputToContain('Request failed: Connection timed out')
+                ->assertFailed();
+        });
+    });
+
+    describe('configuration', function () {
+        it('uses API token from environment variable', function () {
+            putenv('PREFRONTAL_API_TOKEN=env-token');
+
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $responseData = ['fixes' => [], 'minimal_report' => 'OK'];
+
+            $mock = new MockHandler([
+                new Response(200, [], json_encode($responseData)),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--failures' => $this->failuresFile,
+            ])
+                ->assertSuccessful();
+        });
+
+        it('uses API URL from option over environment', function () {
+            putenv('PREFRONTAL_API_URL=https://env-url.example.com');
+
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $responseData = ['fixes' => [], 'minimal_report' => 'OK'];
+
+            $mock = new MockHandler([
+                new Response(200, [], json_encode($responseData)),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient);
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--api-url' => 'https://custom-url.example.com',
+                '--failures' => $this->failuresFile,
+            ])
+                ->assertSuccessful();
+        });
+    });
+
+    describe('detectRepo', function () {
+        it('uses mock repo when provided via withMocks', function () {
+            $failures = [['test' => 'TestFoo', 'message' => 'Failed']];
+            file_put_contents($this->failuresFile, json_encode($failures));
+
+            $responseData = ['fixes' => [], 'minimal_report' => 'OK'];
+
+            $mock = new MockHandler([
+                new Response(200, [], json_encode($responseData)),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+
+            ($this->createCommand)($httpClient, 'custom/repo', 'custom-sha');
+
+            $this->artisan('analyze', [
+                '--api-token' => 'test-token',
+                '--failures' => $this->failuresFile,
+            ])
+                ->assertSuccessful();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Refactored `AnalyzeCommand` to accept injected Guzzle `Client` via `withMocks()` pattern (matching `CertifyCommand`)
- Added `mockRepo` and `mockSha` properties to bypass `shell_exec` calls in tests
- Created `tests/Unit/Commands/AnalyzeCommandTest.php` with 15 tests covering all branches: validation (missing token, missing file, invalid JSON), API interaction (success with fixes, empty fixes, error responses, Guzzle exceptions), and configuration (env vars, option overrides)
- Applied pint style fixes across touched files

## Test plan
- [x] All 218 tests pass
- [x] Pint reports no style issues
- [x] AnalyzeCommand test covers: no token, no file, nonexistent file, invalid JSON, empty JSON array, successful API call with fixes, empty fixes, fix without suggestion, fix with missing type/file, missing minimal_report, invalid API response, Guzzle exception, env token, API URL override, mock repo/sha

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for command functionality, including validation scenarios, API interactions, error handling, and configuration precedence.

* **Refactor**
  * Enhanced command testability through injectable dependencies and mock support.
  * Code cleanup and style improvements across multiple modules for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->