### PR TITLE
fix: handle ProcessTimedOutException and ProcessSignaledException in SymfonyProcessRunner

### DIFF
--- a/app/Commands/CertifyCommand.php
+++ b/app/Commands/CertifyCommand.php
@@ -6,7 +6,6 @@ namespace App\Commands;
 
 use App\Branding;
 use App\Checks\CheckInterface;
-use App\Checks\CheckResult;
 use App\Checks\PestSyntaxValidator;
 use App\Checks\SecurityScanner;
 use App\Checks\TestRunner;
@@ -123,7 +122,7 @@ final class CertifyCommand extends Command
             $checksClient->postCertificationComment($checkResults);
         } else {
             // Post actionable prompt with fix directions on failure
-            $assembler = new PromptAssembler();
+            $assembler = new PromptAssembler;
             $assembled = $assembler->assemble($rawOutputs);
 
             if ($assembled['prompt'] !== '') {

--- a/app/GitHub/ChecksClient.php
+++ b/app/GitHub/ChecksClient.php
@@ -89,6 +89,7 @@ final class ChecksClient
             return $data['id'] ?? null;
         } catch (GuzzleException $e) {
             $this->logError('createCheck', $e);
+
             return null;
         }
     }
@@ -119,6 +120,7 @@ final class ChecksClient
             return true;
         } catch (GuzzleException $e) {
             $this->logError('completeCheck', $e);
+
             return false;
         }
     }
@@ -155,6 +157,7 @@ final class ChecksClient
             return true;
         } catch (GuzzleException $e) {
             $this->logError('reportCheck', $e);
+
             return false;
         }
     }
@@ -199,6 +202,7 @@ MARKDOWN;
             return true;
         } catch (GuzzleException $e) {
             $this->logError('postCertificationComment', $e);
+
             return false;
         }
     }
@@ -234,6 +238,7 @@ MARKDOWN;
             return true;
         } catch (GuzzleException $e) {
             $this->logError('postActionablePrompt', $e);
+
             return false;
         }
     }

--- a/app/Services/PromptAssembler.php
+++ b/app/Services/PromptAssembler.php
@@ -22,8 +22,8 @@ final class PromptAssembler
     public function __construct()
     {
         $this->transformers = [
-            new PhpStanPromptTransformer(),
-            new TestFailurePromptTransformer(),
+            new PhpStanPromptTransformer,
+            new TestFailurePromptTransformer,
         ];
     }
 
@@ -94,7 +94,7 @@ final class PromptAssembler
     private function buildCombinedPrompt(array $failedChecks): string
     {
         $count = count($failedChecks);
-        $prompt = "# 🔧 Synapse Sentinel: {$count} check" . ($count === 1 ? '' : 's') . " need attention\n\n";
+        $prompt = "# 🔧 Synapse Sentinel: {$count} check".($count === 1 ? '' : 's')." need attention\n\n";
         $prompt .= "The following issues must be resolved before this PR can be merged:\n\n";
 
         foreach ($failedChecks as $checkName => $section) {
@@ -117,6 +117,6 @@ final class PromptAssembler
             return $text;
         }
 
-        return substr($text, 0, $maxLength) . "\n... (truncated)";
+        return substr($text, 0, $maxLength)."\n... (truncated)";
     }
 }

--- a/app/Services/SymfonyProcessRunner.php
+++ b/app/Services/SymfonyProcessRunner.php
@@ -6,6 +6,8 @@ namespace App\Services;
 
 use App\Contracts\ProcessResult;
 use App\Contracts\ProcessRunner;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 final class SymfonyProcessRunner implements ProcessRunner
@@ -13,7 +15,22 @@ final class SymfonyProcessRunner implements ProcessRunner
     public function run(array $command, string $workingDirectory, int $timeout = 120): ProcessResult
     {
         $process = new Process($command, $workingDirectory, timeout: $timeout);
-        $process->run();
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $e) {
+            return new ProcessResult(
+                successful: false,
+                output: "Process timed out after {$timeout} seconds: ".$e->getMessage(),
+                exitCode: 124,
+            );
+        } catch (ProcessSignaledException $e) {
+            return new ProcessResult(
+                successful: false,
+                output: 'Process killed by signal: '.$e->getMessage(),
+                exitCode: $e->getProcess()->getExitCode() ?? 137,
+            );
+        }
 
         return new ProcessResult(
             successful: $process->isSuccessful(),

--- a/app/Transformers/PhpStanPromptTransformer.php
+++ b/app/Transformers/PhpStanPromptTransformer.php
@@ -115,7 +115,7 @@ final class PhpStanPromptTransformer implements PromptTransformerInterface
             $relativePath = $this->relativePath($filePath);
             $errorCount = $fileData['errors'] ?? 0;
 
-            $prompt .= "### {$relativePath} ({$errorCount} error" . ($errorCount === 1 ? '' : 's') . ")\n\n";
+            $prompt .= "### {$relativePath} ({$errorCount} error".($errorCount === 1 ? '' : 's').")\n\n";
 
             foreach ($fileData['messages'] ?? [] as $index => $message) {
                 $prompt .= $this->formatError($index + 1, $message);

--- a/app/Transformers/TestFailurePromptTransformer.php
+++ b/app/Transformers/TestFailurePromptTransformer.php
@@ -95,7 +95,6 @@ final class TestFailurePromptTransformer implements PromptTransformerInterface
     /**
      * Extract test cases from a test suite.
      *
-     * @param  \SimpleXMLElement  $suite
      * @param  array<array<string, mixed>>  $failures
      * @param  array<array<string, mixed>>  $errors
      */
@@ -246,7 +245,7 @@ final class TestFailurePromptTransformer implements PromptTransformerInterface
 
         // Truncate if too long
         if (strlen($clean) > 500) {
-            $clean = substr($clean, 0, 500) . '... (truncated)';
+            $clean = substr($clean, 0, 500).'... (truncated)';
         }
 
         return trim($clean);

--- a/tests/Unit/Services/SymfonyProcessRunnerTest.php
+++ b/tests/Unit/Services/SymfonyProcessRunnerTest.php
@@ -51,5 +51,26 @@ describe('SymfonyProcessRunner', function () {
 
             expect($result->successful)->toBeTrue();
         });
+
+        it('returns failed result with exit code 124 on process timeout', function () {
+            $runner = new SymfonyProcessRunner;
+            $result = $runner->run(['sleep', '30'], sys_get_temp_dir(), timeout: 1);
+
+            expect($result)->toBeInstanceOf(ProcessResult::class);
+            expect($result->successful)->toBeFalse();
+            expect($result->exitCode)->toBe(124);
+            expect($result->output)->toContain('Process timed out after 1 seconds');
+        });
+
+        it('returns failed result when process is killed by signal', function () {
+            $runner = new SymfonyProcessRunner;
+            // bash -c that sends SIGKILL to itself
+            $result = $runner->run(['bash', '-c', 'kill -9 $$'], sys_get_temp_dir());
+
+            expect($result)->toBeInstanceOf(ProcessResult::class);
+            expect($result->successful)->toBeFalse();
+            expect($result->output)->toContain('Process killed by signal');
+            expect($result->exitCode)->toBe(137);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Wrap `Process::run()` in try/catch to handle `ProcessTimedOutException` and `ProcessSignaledException` gracefully
- Return a failed `ProcessResult` instead of letting exceptions propagate uncaught through TestRunner, SecurityScanner, and commands
- `ProcessTimedOutException` returns exit code 124 with descriptive message
- `ProcessSignaledException` returns exit code from process (or 137 fallback)

## Test plan
- [x] Added test: process timeout returns failed ProcessResult with exit code 124
- [x] Added test: process killed by signal returns failed ProcessResult with exit code 137
- [x] Existing tests still pass (205 total, all green)
- [x] Ran `vendor/bin/pint` (fixed style in 5 additional files)

Closes #50