### PR TITLE
fix: display full error messages instead of truncated table output

### DIFF
--- a/app/Commands/CertifyCommand.php
+++ b/app/Commands/CertifyCommand.php
@@ -18,7 +18,6 @@ use LaravelZero\Framework\Commands\Command;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\table;
 
 final class CertifyCommand extends Command
 {
@@ -146,10 +145,11 @@ final class CertifyCommand extends Command
             error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
 
             if (! empty($failureRows)) {
-                table(
-                    headers: ['Check', 'Issue'],
-                    rows: $failureRows
-                );
+                $this->newLine();
+                foreach ($failureRows as $row) {
+                    $this->line("  <fg=red>✗</> <fg=white;options=bold>{$row[0]}</>: {$row[1]}");
+                }
+                $this->newLine();
             }
         }
 

--- a/tests/Unit/Commands/CertifyCommandTest.php
+++ b/tests/Unit/Commands/CertifyCommandTest.php
@@ -322,6 +322,61 @@ describe('CertifyCommand', function () {
                 ->assertFailed();
         });
 
+        it('displays full error messages without truncation', function () {
+            $longDetail = 'Error in src/Services/PaymentGateway.php: Method processTransaction() has cyclomatic complexity of 25 which exceeds the configured maximum of 10. Consider refactoring this method into smaller, more focused methods to improve maintainability and testability.';
+
+            $failingCheck = Mockery::mock(CheckInterface::class);
+            $failingCheck->shouldReceive('name')->andReturn('Tests');
+            $failingCheck->shouldReceive('run')
+                ->once()
+                ->andReturn(CheckResult::fail('1 test failed', [$longDetail]));
+
+            $mock = new MockHandler([
+                new Response(201),
+                new Response(201),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+            $checksClient = new ChecksClient('token', $httpClient, 'owner/repo', 'sha123');
+
+            ($this->createCommand)([$failingCheck], $checksClient);
+
+            $this->artisan('certify')
+                ->expectsOutputToContain($longDetail)
+                ->assertFailed();
+        });
+
+        it('displays multiple long error details from different checks', function () {
+            $detail1 = 'FAIL Tests\\Unit\\OrderServiceTest > it calculates the total price correctly including tax, shipping, and discount adjustments for international orders';
+            $detail2 = 'CVE-2024-9999: Critical vulnerability found in vendor/acme/library v2.3.1 - Remote code execution via deserialization of untrusted data in JsonParser::decode()';
+
+            $failingCheck1 = Mockery::mock(CheckInterface::class);
+            $failingCheck1->shouldReceive('name')->andReturn('Tests');
+            $failingCheck1->shouldReceive('run')
+                ->once()
+                ->andReturn(CheckResult::fail('Tests failed', [$detail1]));
+
+            $failingCheck2 = Mockery::mock(CheckInterface::class);
+            $failingCheck2->shouldReceive('name')->andReturn('Security');
+            $failingCheck2->shouldReceive('run')
+                ->once()
+                ->andReturn(CheckResult::fail('Security failed', [$detail2]));
+
+            $mock = new MockHandler([
+                new Response(201),
+                new Response(201),
+                new Response(201),
+            ]);
+            $httpClient = new Client(['handler' => HandlerStack::create($mock)]);
+            $checksClient = new ChecksClient('token', $httpClient, 'owner/repo', 'sha123');
+
+            ($this->createCommand)([$failingCheck1, $failingCheck2], $checksClient);
+
+            $this->artisan('certify')
+                ->expectsOutputToContain($detail1)
+                ->expectsOutputToContain($detail2)
+                ->assertFailed();
+        });
+
         it('shortens check names in compact output', function () {
             // This test covers the shortName() method by using the actual check names
             $testsCheck = Mockery::mock(CheckInterface::class);


### PR DESCRIPTION
## Problem

Laravel Prompts `table()` function truncates long error messages at column width limits (~140 characters), making it impossible for users to debug test failures.

## Root Cause

**File**: `app/Commands/CertifyCommand.php:149-152`

The `table()` function formats output in fixed-width columns, causing truncation like:
```
│ Tests & Coverage │ bifrost:withings:auth → it shows auth URL when no code provided: ! bifrost:withings:auth → it fails when client_id is missing → file_g… 0.02s │
```

## Solution

- Removed `table()` import and call
- Replaced with line-by-line output using `$this->line()`  
- Format: `✗ CheckName: full error message`
- No character limits or truncation

## Testing

Added regression test with 260+ character error message to verify full display without truncation.

## Impact

- ✅ Users can now see complete error messages for debugging
- ✅ Maintains visual formatting with colored output
- ✅ Backward compatible - no breaking changes
- ✅ Fixes critical issue blocking multiple repositories

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated failure message display format for better readability and clarity
  * Long error messages from failing checks are now displayed in full without truncation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->